### PR TITLE
Addressing situation when `direction` is None

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,8 @@ use semsimian::{RustSemsimian, TermID};
 
 use utils::get_rss_instance;
 
-use crate::utils::MetricEnumWrapper;
 use crate::utils::DirectionalityEnumWrapper;
+use crate::utils::MetricEnumWrapper;
 
 pub mod utils;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use std::sync::Mutex;
 use lazy_static::lazy_static;
 use rocket::request::FromParam;
 use rocket::serde::json::Json;
-use semsimian::enums::SearchTypeEnum;
+use semsimian::enums::{DirectionalityEnum, SearchTypeEnum};
 use semsimian::termset_pairwise_similarity::{
     TermsetPairwiseSimilarity as Tsps, TermsetPairwiseSimilarity,
 };
@@ -76,6 +76,10 @@ pub fn search(
     let search_type: SearchTypeEnum = SearchTypeEnum::Hybrid;
     let limit: usize = limit.unwrap_or(10);
 
+    let direction_enum = direction
+        .map(|d| DirectionalityEnumWrapper::from_param(d).unwrap().0)
+        .unwrap_or(DirectionalityEnum::Bidirectional);
+
     // Call the function under test
     let result = RSS_MUTEX.lock().unwrap().associations_search(
         &assoc_predicate,
@@ -87,6 +91,7 @@ pub fn search(
         // convert metric string to MetricEnum using from_string respecting Option expected by the from_string function
         &MetricEnumWrapper::from_param(metric.unwrap()).unwrap(),
         Some(limit),
+        &Some(direction_enum),
         &Some(DirectionalityEnumWrapper::from_param(direction.unwrap()).unwrap().0),
     );
     println!("Result - {:?}", result);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,6 @@ pub fn search(
         &MetricEnumWrapper::from_param(metric.unwrap()).unwrap(),
         Some(limit),
         &Some(direction_enum),
-        &Some(DirectionalityEnumWrapper::from_param(direction.unwrap()).unwrap().0),
     );
     println!("Result - {:?}", result);
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -79,7 +79,6 @@ impl<'a> FromParam<'a> for MetricEnumWrapper {
     }
 }
 
-
 pub struct DirectionalityEnumWrapper(pub DirectionalityEnum);
 
 impl<'a> FromParam<'a> for DirectionalityEnumWrapper {
@@ -88,13 +87,16 @@ impl<'a> FromParam<'a> for DirectionalityEnumWrapper {
     fn from_param(param: &'a str) -> Result<Self, Self::Error> {
         match param {
             "bidirectional" => Ok(DirectionalityEnumWrapper(DirectionalityEnum::Bidirectional)),
-            "subject_to_object" => Ok(DirectionalityEnumWrapper(DirectionalityEnum::SubjectToObject)),
-            "object_to_subject" => Ok(DirectionalityEnumWrapper(DirectionalityEnum::ObjectToSubject)),
+            "subject_to_object" => Ok(DirectionalityEnumWrapper(
+                DirectionalityEnum::SubjectToObject,
+            )),
+            "object_to_subject" => Ok(DirectionalityEnumWrapper(
+                DirectionalityEnum::ObjectToSubject,
+            )),
             _ => Ok(DirectionalityEnumWrapper(DirectionalityEnum::Bidirectional)),
         }
     }
 }
-
 
 // Implement Deref so you can use the wrapper type like the original enum
 use std::ops::Deref;


### PR DESCRIPTION
Added the line:
```
let direction_enum = direction
        .map(|d| DirectionalityEnumWrapper::from_param(d).unwrap().0)
        .unwrap_or(DirectionalityEnum::Bidirectional);

```

So the association_search call changes to :

```
// Call the function under test
    let result = RSS_MUTEX.lock().unwrap().associations_search(
        &assoc_predicate,
        &object_terms,
        true,
        &None,
        &subject_prefixes,
        &search_type,
        // convert metric string to MetricEnum using from_string respecting Option expected by the from_string function
        &MetricEnumWrapper::from_param(metric.unwrap()).unwrap(),
        Some(limit),
        &Some(direction_enum),
    );
```