### PR TITLE
Share cache between compare and search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1661,6 +1661,8 @@ version = "0.2.2"
 dependencies = [
  "clap",
  "lazy_static",
+ "num_cpus",
+ "rand",
  "rocket",
  "semsimian",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1638,8 +1638,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "semsimian"
 version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1138b6114ac753bef97bc926c8b10c9a51a43ef98f5a7a6d6b74722efc96a42d"
+source = "git+https://github.com/monarch-initiative/semsimian.git?branch=association-search-with-cache#2974277cd503ba46348f5834ee8a3cdd7cbafd96"
 dependencies = [
  "cargo-llvm-cov",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "BSD-3-Clause"
 authors = ["Glass Ships <glass.ships@protonmail.com"]
 
 [dependencies]
-semsimian = "=0.2.19"
+semsimian = { git = "https://github.com/monarch-initiative/semsimian.git", branch = "association-search-with-cache" }
 clap = { version = "4.5.40", features = ["derive"] }
 lazy_static = { version = ">=1.5.0", features = [] }
 rocket = { version = "0.5.1", features = ["json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ clap = { version = "4.5.40", features = ["derive"] }
 lazy_static = { version = ">=1.5.0", features = [] }
 rocket = { version = "0.5.1", features = ["json"] }
 serde = ">=1.0.219"
+num_cpus = "1.0"
+rand = "0.8"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 use rocket::request::FromParam;
 use semsimian::enums::{DirectionalityEnum, MetricEnum, SearchTypeEnum};
 use semsimian::{Predicate, RustSemsimian, TermID};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Mutex;
 
@@ -59,6 +59,21 @@ pub fn get_rss_instance() -> RustSemsimian {
 
     // Now rss_instance is an Option<RustSemsimian>
     rss_instance.unwrap()
+}
+
+pub fn get_association_cache() -> HashMap<String, HashSet<String>> {
+    let rss = get_rss_instance();
+    let assoc_predicate: HashSet<TermID> = HashSet::from(["biolink:has_phenotype".to_string()]);
+    let subject_prefixes: Option<Vec<TermID>> = None;
+    let subject_set: Option<HashSet<TermID>> = None;
+    let search_type: SearchTypeEnum = SearchTypeEnum::Hybrid;
+    
+    rss.generate_associations_cache(
+        &assoc_predicate,
+        &subject_set,
+        &subject_prefixes,
+        &search_type,
+    )
 }
 
 // Define a wrapper type in your own crate


### PR DESCRIPTION
  - Update semsimian dependency to use shared cache functionality from PR #138
  - Implement global association cache to reduce memory usage across API workers
  - Migrate `/search` endpoint to use cache-enabled association search

  ## Background

  Previously, each API worker maintained its own association search cache, resulting in duplicated memory usage. This PR implements the shared cache
  functionality introduced in [semsimian PR #138](https://github.com/monarch-initiative/semsimian/pull/138) to allow cache sharing across workers.

  ## Changes Made

  ### Dependency Update
  - Updated `Cargo.toml` to depend on `semsimian` branch `association-search-with-cache`

  ### Cache Implementation
  - Added global `ASSOCIATION_CACHE` using `lazy_static` for shared cache storage
  - Created `get_association_cache()` function to generate cache at startup
  - Modified `/search` endpoint to use `associations_search_with_cache()` instead of `associations_search()`

  ### Code Quality Improvements
  - Added inline parameter comments for better readability of complex function calls
  - Fixed compilation warnings

  ## Memory Usage Impact

  This change reduces memory consumption by eliminating duplicate association caches across API workers. The cache is now generated once at startup
  and shared across all search operations.

  ## Testing

  - All existing tests pass with `PHENIO_PATH=./phenio.db`
  - Cache generation works correctly and is shared across API calls
  - No breaking changes to existing API endpoints

  ## Usage Notes

  Remember to set the `PHENIO_PATH` environment variable when running the server:
  ```bash
  PHENIO_PATH=./phenio.db cargo run --release
