### PR TITLE
fix: check_for_phenio() now respects PHENIO_PATH env var

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,31 +6,36 @@ use semsimian::enums::{ DirectionalityEnum, MetricEnum, SearchTypeEnum };
 use semsimian::{ Predicate, RustSemsimian, TermID };
 use flate2::read::GzDecoder;
 
-// Check for phenio.db in ~/.data/oaklib, download if not present
 const PHENIO_DB_URL: &str = "https://data.monarchinitiative.org/monarch-kg-dev/latest/phenio.db.gz";
 
-pub fn check_for_phenio() {
-    let mut db_path = PathBuf::new();
-    if let Some(home) = std::env::var_os("HOME") {
-        db_path.push(home);
-        db_path.push(".data/oaklib/phenio.db");
+/// Resolve the phenio.db path: PHENIO_PATH env var takes priority,
+/// otherwise fall back to $HOME/.data/oaklib/phenio.db.
+fn resolve_phenio_path() -> PathBuf {
+    if let Some(phenio_path) = std::env::var_os("PHENIO_PATH") {
+        PathBuf::from(phenio_path)
+    } else if let Some(home) = std::env::var_os("HOME") {
+        let mut p = PathBuf::from(home);
+        p.push(".data/oaklib/phenio.db");
+        p
     } else {
-        panic!("Failed to get home directory");
+        panic!("Neither PHENIO_PATH nor HOME is set");
     }
+}
+
+/// Check for phenio.db at the resolved path, download if not present.
+pub fn check_for_phenio() {
+    let db_path = resolve_phenio_path();
 
     if db_path.exists() {
-        println!("phenio.db found, launching server");
+        println!("phenio.db found at {}, launching server", db_path.display());
     } else {
-        println!("phenio.db not found, downloading from {}", PHENIO_DB_URL);
-        // Download the phenio.db.gz file
+        println!("phenio.db not found at {}, downloading from {}", db_path.display(), PHENIO_DB_URL);
         let response = reqwest::blocking
             ::get(PHENIO_DB_URL)
             .expect("Failed to download phenio.db.gz");
-        
-        // Create the directory if it doesn't exist
+
         std::fs::create_dir_all(db_path.parent().unwrap()).expect("Failed to create directory");
 
-        // Unpack the .gz
         let mut gz = GzDecoder::new(response);
         let mut out_file = std::fs::File
             ::create(&db_path)
@@ -39,18 +44,8 @@ pub fn check_for_phenio() {
     }
 }
 
-// Get a RustSemsimian instance, ensure phenio.db
 pub fn get_rss_instance() -> RustSemsimian {
-    let mut db_path = PathBuf::new();
-    //if PHENIO_PATH is in the environment, use that as db_path, else use ~/.data/oaklib/phenio.db
-    if let Some(phenio_path) = std::env::var_os("PHENIO_PATH") {
-        db_path.push(phenio_path);
-    } else if let Some(home) = std::env::var_os("HOME") {
-        db_path.push(home);
-        db_path.push(".data/oaklib/phenio.db");
-    } else {
-        panic!("Failed to get home directory");
-    }
+    let db_path = resolve_phenio_path();
     let db = Some(db_path.to_str().expect("Failed to convert path to string"));
     // let db = check_for_phenio();
 

--- a/tests/test_concurrent.rs
+++ b/tests/test_concurrent.rs
@@ -1,0 +1,56 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
+
+use axum::extract::{Path, Query};
+use semsimian_server::{search, SearchParams, QueryParams};
+
+#[tokio::test]
+async fn test_concurrent_search_operations() {
+    let num_tasks = 5;
+    let requests_per_task = 2;
+    let completed_requests = Arc::new(AtomicUsize::new(0));
+    let start_time = Instant::now();
+
+    println!("Starting {} concurrent search operations...", num_tasks * requests_per_task);
+
+    let mut handles = Vec::new();
+    for task_id in 0..num_tasks {
+        let completed = Arc::clone(&completed_requests);
+        handles.push(tokio::spawn(async move {
+            for request_id in 0..requests_per_task {
+                let task_start = Instant::now();
+
+                let _response = search(
+                    Path(SearchParams {
+                        termset: "HP:0000001,HP:0000002".to_string(),
+                        prefix: "ZFIN".to_string(),
+                        metric: Some("ancestor_information_content".to_string()),
+                    }),
+                    Query(QueryParams {
+                        limit: Some(1),
+                        direction: Some("bidirectional".to_string()),
+                    }),
+                ).await;
+
+                let task_elapsed = task_start.elapsed();
+                let total_completed = completed.fetch_add(1, Ordering::Relaxed) + 1;
+
+                println!("Task {} Request {} completed in {:?} (Total: {})",
+                         task_id, request_id, task_elapsed, total_completed);
+            }
+        }));
+    }
+
+    for handle in handles {
+        handle.await.unwrap();
+    }
+
+    let total_time = start_time.elapsed();
+    let total_requests = completed_requests.load(Ordering::Relaxed);
+
+    println!("All {} requests completed in {:?}", total_requests, total_time);
+    println!("Average time per request: {:?}", total_time / total_requests as u32);
+
+    assert_eq!(total_requests, num_tasks * requests_per_task);
+}


### PR DESCRIPTION
## Summary

- **Bug**: `check_for_phenio()` ignored the `PHENIO_PATH` environment variable and always checked `$HOME/.data/oaklib/phenio.db`. In Docker, where `PHENIO_PATH` points to a host-mounted database and `HOME=/usr/src/semsimian_server`, this caused a redundant ~19GB download into the container writable layer on every startup — filling the disk after a few restarts.
- **Fix**: Extract shared path resolution into `resolve_phenio_path()` so both `check_for_phenio()` and `get_rss_instance()` use the same `PHENIO_PATH`-first logic.
- Improved log messages to print the resolved path for easier debugging.

Closes monarch-initiative/monarch-stack-v3#41

